### PR TITLE
Added vkEnumerateInstanceVersion to preloaded commands

### DIFF
--- a/vk.generator/Program.cs
+++ b/vk.generator/Program.cs
@@ -184,7 +184,8 @@ namespace vk.generator {
 										"vkGetDeviceProcAddr",
 										"vkGetInstanceProcAddr",
 										"vkEnumerateInstanceExtensionProperties",
-										"vkEnumerateInstanceLayerProperties"};
+										"vkEnumerateInstanceLayerProperties",
+										"vkEnumerateInstanceVersion"};
 
         static string[] reservedNames = { "event", "object" };
 


### PR DESCRIPTION
vkEnumerateInstanceVersion might be wanted when creating an instance of validating the version of Vulkan on a system before starting a program